### PR TITLE
build doc + electron update

### DIFF
--- a/docs/windows-build-on-nix
+++ b/docs/windows-build-on-nix
@@ -1,0 +1,20 @@
+## Preparing System (Ubuntu 16.04)
+1-`sudo apt update`  
+2-`sudo apt upgrade -y`  
+3-`sudo dpkg --add-architecture i386`  
+4-`sudo apt install -y curl build-essential git` <- answer yes to any popups  
+5-`curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -`  
+6-`sudo apt install -y nodejs`  
+7-`node -v` <- ensure it show 0.10 or higher  
+8-`npm -v` <- ensure it shows 6.0 or higher  
+9-`npm install concurrently`  
+10-`sudo apt-add-repository 'deb https://dl.winehq.org/wine-builds/ubuntu/ xenial main'`  
+11-`sudo apt update && sudo apt-get install --install-recommends winehq-stable`  
+
+## Building Source  
+1-`cd ~ && mkdir build && cd build`  
+2-`git clone https://github.com/Nexusoft/NexusInterface.git nexus`  
+3-`cd nexus && npm install` <- if it succeeds continue  
+4-`chmod a+x BuildStandalone-Windows.sh`  
+5-`./BuildStandalone-Windows.sh`  
+6-Find your installer file in the "Release" folder and enjoy :)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nexus_wallet",
-  "version": "1.1.1",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -5120,19 +5120,19 @@
       "integrity": "sha512-x8EXrqFbAb2L3N22YlGar3dGh8vwptbB3ovo3OF6K7NTpcsmM2zEoJv7GhFyX73rNzSG2HaWpXwGAtOp2JWiEw==",
       "dev": true,
       "requires": {
-        "app-builder-lib": "21.0.15",
+        "app-builder-lib": "21.2.0",
         "bluebird-lst": "^1.0.9",
-        "builder-util": "21.0.15",
+        "builder-util": "21.2.0",
         "builder-util-runtime": "8.3.0",
         "chalk": "^2.4.2",
-        "dmg-builder": "21.0.15",
+        "dmg-builder": "21.2.0",
         "fs-extra": "^8.1.0",
         "is-ci": "^2.0.0",
         "lazy-val": "^1.0.4",
-        "read-config-file": "4.0.1",
-        "sanitize-filename": "^1.6.1",
+        "read-config-file": "5.0.0",
+        "sanitize-filename": "^1.6.2",
         "update-notifier": "^3.0.1",
-        "yargs": "^13.2.4"
+        "yargs": "^13.3.0"
       },
       "dependencies": {
         "ansi-align": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nexus_wallet",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -5096,9 +5096,9 @@
       "dev": true
     },
     "electron": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-5.0.6.tgz",
-      "integrity": "sha512-0L53lv26eDhaaNxL6DqXGQrQOEAYbrQg40stRSb2pzrY06kwPbABzXEiaCvEsBuKUQ+9OQBbVyyvXRbLJlun/A==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-6.0.0.tgz",
+      "integrity": "sha512-JVHj0dYtvVFrzVk1TgvrdXJSyLpdvlWNLhtG8ItYZsyg9XbCOQ9OoPfgLm04FjMzKMzEl4YIN0PfGC02MTx3PQ==",
       "dev": true,
       "requires": {
         "@types/node": "^10.12.18",
@@ -5115,9 +5115,9 @@
       }
     },
     "electron-builder": {
-      "version": "21.0.15",
-      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-21.0.15.tgz",
-      "integrity": "sha512-ENvaU8+UwLAd4hIgOib1KyB1Ap119VrrEj4tBgihuKDgsNUgV7qt2YUdYA6umcUKPAE+ewWBfPLzg+q0gqWTIQ==",
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-21.2.0.tgz",
+      "integrity": "sha512-x8EXrqFbAb2L3N22YlGar3dGh8vwptbB3ovo3OF6K7NTpcsmM2zEoJv7GhFyX73rNzSG2HaWpXwGAtOp2JWiEw==",
       "dev": true,
       "requires": {
         "app-builder-lib": "21.0.15",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nexus_wallet",
   "productName": "Nexus Wallet",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "moduleSpecVersion": "0.2.0",
   "supportedModuleSpecVersion": "0.1.0",
   "buildDate": "July 19th 2019",
@@ -32,8 +32,7 @@
     "update-translations": "node ./internals/scripts/updateTranslations.js",
     "update-documentation": "./UpdateDocumentation.sh"
   },
-  "browserslist": "electron 5.0.6",
-  "main": "./build/main.prod.js",
+  "browserslist": "electron "6.0.0  "main": "./build/main.prod.js",
   "build": {
     "productName": "Nexus Wallet",
     "appId": "com.nexusearth.NexusTritium",
@@ -183,8 +182,8 @@
     "cross-env": "^5.2.0",
     "cross-spawn": "^6.0.5",
     "css-loader": "^3.0.0",
-    "electron": "^5.0.6",
-    "electron-builder": "^21.0.15",
+    "electron": "^6.0.0",
+    "electron-builder": "^21.2.0",
     "electron-devtools-installer": "^2.2.4",
     "eslint": "^6.0.1",
     "express": "^4.17.1",

--- a/package.json.save
+++ b/package.json.save
@@ -32,7 +32,7 @@
     "update-translations": "node ./internals/scripts/updateTranslations.js",
     "update-documentation": "./UpdateDocumentation.sh"
   },
-  "browserslist": "electron 6.0.0",
+  "browserslist": "electron "
   "main": "./build/main.prod.js",
   "build": {
     "productName": "Nexus Wallet",
@@ -183,8 +183,8 @@
     "cross-env": "^5.2.0",
     "cross-spawn": "^6.0.5",
     "css-loader": "^3.0.0",
-    "electron": "^6.0.0",
-    "electron-builder": "^21.2.0",
+    "electron": "^5.0.6",
+    "electron-builder": "^21.0.15",
     "electron-devtools-installer": "^2.2.4",
     "eslint": "^6.0.1",
     "express": "^4.17.1",


### PR DESCRIPTION
-update electron 6.0.0
-update electron-builder 21.2.0
-Add more in depth instructions for building windows wallet files on Linux
should fix issue #56 and issue #55 on ubuntu gnome based distros (16.04-19.04), however it is still unusable on Debian 9 & 10