### PR TITLE
Doc update windows-build + SUID fix - downgrade electron

### DIFF
--- a/docs/windows-build-on-nix
+++ b/docs/windows-build-on-nix
@@ -1,0 +1,20 @@
+## Preparing System (Ubuntu 16.04)
+1-`sudo apt update`  
+2-`sudo apt upgrade -y`  
+3-`sudo dpkg --add-architecture i386`  
+4-`sudo apt install -y curl build-essential git` <- answer yes to any popups  
+5-`curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -`  
+6-`sudo apt install -y nodejs`  
+7-`node -v` <- ensure it show 0.10 or higher  
+8-`npm -v` <- ensure it shows 6.0 or higher  
+9-`npm install concurrently`  
+10-`sudo apt-add-repository 'deb https://dl.winehq.org/wine-builds/ubuntu/ xenial main'`  
+11-`sudo apt update && sudo apt-get install --install-recommends winehq-stable`  
+
+## Building Source  
+1-`cd ~ && mkdir build && cd build`  
+2-`git clone https://github.com/Nexusoft/NexusInterface.git nexus`  
+3-`cd nexus && npm install` <- if it succeeds continue  
+4-`chmod a+x BuildStandalone-Windows.sh`  
+5-`./BuildStandalone-Windows.sh`  
+6-Find your installer file in the "Release" folder and enjoy :)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nexus_wallet",
-  "version": "1.1.1",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -5120,19 +5120,19 @@
       "integrity": "sha512-x8EXrqFbAb2L3N22YlGar3dGh8vwptbB3ovo3OF6K7NTpcsmM2zEoJv7GhFyX73rNzSG2HaWpXwGAtOp2JWiEw==",
       "dev": true,
       "requires": {
-        "app-builder-lib": "21.0.15",
+        "app-builder-lib": "21.2.0",
         "bluebird-lst": "^1.0.9",
-        "builder-util": "21.0.15",
+        "builder-util": "21.2.0",
         "builder-util-runtime": "8.3.0",
         "chalk": "^2.4.2",
-        "dmg-builder": "21.0.15",
+        "dmg-builder": "21.2.0",
         "fs-extra": "^8.1.0",
         "is-ci": "^2.0.0",
         "lazy-val": "^1.0.4",
-        "read-config-file": "4.0.1",
-        "sanitize-filename": "^1.6.1",
+        "read-config-file": "5.0.0",
+        "sanitize-filename": "^1.6.2",
         "update-notifier": "^3.0.1",
-        "yargs": "^13.2.4"
+        "yargs": "^13.3.0"
       },
       "dependencies": {
         "ansi-align": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nexus_wallet",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -8,12 +8,6 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/7zip/-/7zip-0.0.6.tgz",
       "integrity": "sha1-nK+xca+CMpSQNTtIFvAzR6oVCjA=",
-      "dev": true
-    },
-    "7zip-bin": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/7zip-bin/-/7zip-bin-4.1.0.tgz",
-      "integrity": "sha512-AsnBZN3a8/JcNt+KPkGGODaA4c7l3W5+WpeKgGSbstSLxqWtTXqd1ieJGBQ8IFCtRg8DmmKUcSkIkUc0A4p3YA==",
       "dev": true
     },
     "@babel/cli": {
@@ -1655,10 +1649,20 @@
         }
       }
     },
+    "@develar/schema-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@develar/schema-utils/-/schema-utils-2.1.0.tgz",
+      "integrity": "sha512-qjCqB4ctMig9Gz5bd6lkdFr3bO6arOdQqptdBSpF1ZpCnjofieCciEzkoS9ujY9cMGyllYSCSmBJ3x9OKHXzoA==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.1.0",
+        "ajv-keywords": "^3.1.0"
+      }
+    },
     "@emotion/cache": {
-      "version": "10.0.14",
-      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.14.tgz",
-      "integrity": "sha512-HNGEwWnPlNyy/WPXBXzbjzkzeZFV657Z99/xq2xs5yinJHbMfi3ioCvBJ6Y8Zc8DQzO9F5jDmVXJB41Ytx3QMw==",
+      "version": "10.0.15",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.15.tgz",
+      "integrity": "sha512-8VthgeKhlGeTXSW1JN7I14AnAaiFPbOrqNqg3dPoGCZ3bnMjkrmRU0zrx0BtBw9esBaPaQgDB9y0tVgAGT2Mrg==",
       "requires": {
         "@emotion/sheet": "0.9.3",
         "@emotion/stylis": "0.8.4",
@@ -1667,16 +1671,30 @@
       }
     },
     "@emotion/core": {
-      "version": "10.0.14",
-      "resolved": "https://registry.npmjs.org/@emotion/core/-/core-10.0.14.tgz",
-      "integrity": "sha512-G9FbyxLm3lSnPfLDcag8fcOQBKui/ueXmWOhV+LuEQg9HrqExuWnWaO6gm6S5rNe+AMcqLXVljf8pYgAdFLNSg==",
+      "version": "10.0.15",
+      "resolved": "https://registry.npmjs.org/@emotion/core/-/core-10.0.15.tgz",
+      "integrity": "sha512-VHwwl3k/ddMfQOHYgOJryXOs2rGJ5AfKLQGm5AVolNonnr6tkmDI4nzIMNaPpveoXVs7sP0OrF24UunIPxveQw==",
       "requires": {
         "@babel/runtime": "^7.4.3",
-        "@emotion/cache": "^10.0.14",
+        "@emotion/cache": "^10.0.15",
         "@emotion/css": "^10.0.14",
-        "@emotion/serialize": "^0.11.8",
+        "@emotion/serialize": "^0.11.9",
         "@emotion/sheet": "0.9.3",
         "@emotion/utils": "0.11.2"
+      },
+      "dependencies": {
+        "@emotion/serialize": {
+          "version": "0.11.9",
+          "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-0.11.9.tgz",
+          "integrity": "sha512-/Cn4V81z3ZyFiDQRw8nhGFaHkxHtmCSSBUit4vgTuLA1BqxfJUYiqSq97tq/vV8z9LfIoqs6a9v6QrUFWZpK7A==",
+          "requires": {
+            "@emotion/hash": "0.7.2",
+            "@emotion/memoize": "0.7.2",
+            "@emotion/unitless": "0.7.4",
+            "@emotion/utils": "0.11.2",
+            "csstype": "^2.5.7"
+          }
+        }
       }
     },
     "@emotion/css": {
@@ -1687,30 +1705,6 @@
         "@emotion/serialize": "^0.11.8",
         "@emotion/utils": "0.11.2",
         "babel-plugin-emotion": "^10.0.14"
-      },
-      "dependencies": {
-        "babel-plugin-emotion": {
-          "version": "10.0.14",
-          "resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-10.0.14.tgz",
-          "integrity": "sha512-T7hdxJ4xXkKW3OXcizK0pnUJlBeNj/emjQZPDIZvGOuwl2adIgicQWRNkz6BuwKdDTrqaXQn1vayaL6aL8QW5A==",
-          "requires": {
-            "@babel/helper-module-imports": "^7.0.0",
-            "@emotion/hash": "0.7.2",
-            "@emotion/memoize": "0.7.2",
-            "@emotion/serialize": "^0.11.8",
-            "babel-plugin-macros": "^2.0.0",
-            "babel-plugin-syntax-jsx": "^6.18.0",
-            "convert-source-map": "^1.5.0",
-            "escape-string-regexp": "^1.0.5",
-            "find-root": "^1.1.0",
-            "source-map": "^0.5.7"
-          }
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-        }
       }
     },
     "@emotion/hash": {
@@ -1749,23 +1743,35 @@
       "integrity": "sha512-c3Q6V7Df7jfwSq5AzQWbXHa5soeE4F5cbqi40xn0CzXxWW9/6Mxq48WJEtqfWzbZtW9odZdnRAkwCQwN12ob4A=="
     },
     "@emotion/styled": {
-      "version": "10.0.14",
-      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-10.0.14.tgz",
-      "integrity": "sha512-Ae8d5N/FmjvZKXjqWcjfhZhjCdkvxZSqD95Q72BYDNQnsOKLHIA4vWlMolLXDNkw1dIxV3l2pp82Z87HXj6eYQ==",
+      "version": "10.0.15",
+      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-10.0.15.tgz",
+      "integrity": "sha512-vIKDo/hG741PNRpMnrJ6R8NnnjYfOBw3d6cb3yNckpjcp0NNq3ugE8/EjcYBU1Ke44nx2p00h5uzE396xOLJIg==",
       "requires": {
-        "@emotion/styled-base": "^10.0.14",
-        "babel-plugin-emotion": "^10.0.14"
+        "@emotion/styled-base": "^10.0.15",
+        "babel-plugin-emotion": "^10.0.15"
       },
       "dependencies": {
+        "@emotion/serialize": {
+          "version": "0.11.9",
+          "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-0.11.9.tgz",
+          "integrity": "sha512-/Cn4V81z3ZyFiDQRw8nhGFaHkxHtmCSSBUit4vgTuLA1BqxfJUYiqSq97tq/vV8z9LfIoqs6a9v6QrUFWZpK7A==",
+          "requires": {
+            "@emotion/hash": "0.7.2",
+            "@emotion/memoize": "0.7.2",
+            "@emotion/unitless": "0.7.4",
+            "@emotion/utils": "0.11.2",
+            "csstype": "^2.5.7"
+          }
+        },
         "babel-plugin-emotion": {
-          "version": "10.0.14",
-          "resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-10.0.14.tgz",
-          "integrity": "sha512-T7hdxJ4xXkKW3OXcizK0pnUJlBeNj/emjQZPDIZvGOuwl2adIgicQWRNkz6BuwKdDTrqaXQn1vayaL6aL8QW5A==",
+          "version": "10.0.15",
+          "resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-10.0.15.tgz",
+          "integrity": "sha512-E3W68Zk8EcKpRUDW2tsFKi4gsavapMRjfr2/KKgG3l7l2zZpiKk0BxB59Ul9C0w0ekv6my/ylGOk2WroaqKXPw==",
           "requires": {
             "@babel/helper-module-imports": "^7.0.0",
             "@emotion/hash": "0.7.2",
             "@emotion/memoize": "0.7.2",
-            "@emotion/serialize": "^0.11.8",
+            "@emotion/serialize": "^0.11.9",
             "babel-plugin-macros": "^2.0.0",
             "babel-plugin-syntax-jsx": "^6.18.0",
             "convert-source-map": "^1.5.0",
@@ -1782,14 +1788,28 @@
       }
     },
     "@emotion/styled-base": {
-      "version": "10.0.14",
-      "resolved": "https://registry.npmjs.org/@emotion/styled-base/-/styled-base-10.0.14.tgz",
-      "integrity": "sha512-1nC5iO/Rk0DY47M5wXCyWpbo/woiwXWfVbNKDM3QRi7CKq8CwC++PQ5HgiYflFrAt1vjzIVZqnzrIn3idUoQgg==",
+      "version": "10.0.15",
+      "resolved": "https://registry.npmjs.org/@emotion/styled-base/-/styled-base-10.0.15.tgz",
+      "integrity": "sha512-u1mtdoEip9uf0Wa/CrgLNFiu5pP6annTHyZGGinBisk/dRGyfq3NB7suum8HeMu26xXk7b5/qseDlrsoHq75KQ==",
       "requires": {
         "@babel/runtime": "^7.4.3",
         "@emotion/is-prop-valid": "0.8.2",
-        "@emotion/serialize": "^0.11.8",
+        "@emotion/serialize": "^0.11.9",
         "@emotion/utils": "0.11.2"
+      },
+      "dependencies": {
+        "@emotion/serialize": {
+          "version": "0.11.9",
+          "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-0.11.9.tgz",
+          "integrity": "sha512-/Cn4V81z3ZyFiDQRw8nhGFaHkxHtmCSSBUit4vgTuLA1BqxfJUYiqSq97tq/vV8z9LfIoqs6a9v6QrUFWZpK7A==",
+          "requires": {
+            "@emotion/hash": "0.7.2",
+            "@emotion/memoize": "0.7.2",
+            "@emotion/unitless": "0.7.4",
+            "@emotion/utils": "0.11.2",
+            "csstype": "^2.5.7"
+          }
+        }
       }
     },
     "@emotion/stylis": {
@@ -2126,14 +2146,14 @@
       }
     },
     "acorn": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.4.tgz",
-      "integrity": "sha512-VY4i5EKSKkofY2I+6QLTbTTN/UvEQPCo6eiwzzSaSWfpaDhOmStMCMod6wmuPciNq+XS0faCglFu2lHZpdHUtg=="
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.1.tgz",
+      "integrity": "sha512-JD0xT5FCRDNyjDda3Lrg/IxFscp9q4tiYtxE1/nOzlKCk7hIRuYjhq1kCNkbPjMRMZuFq20HNQn1I9k8Oj0E+Q=="
     },
     "acorn-globals": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.2.tgz",
-      "integrity": "sha512-BbzvZhVtZP+Bs1J1HcwrQe8ycfO0wStkSGxuul3He3GkHOIZ6eTqOkPuw9IP1X3+IkOo4wiJmwkobzXYz4wewQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.3.tgz",
+      "integrity": "sha512-vkR40VwS2SYO98AIeFvzWWh+xyc2qi9s7OoXSFEGIP/rOJKzjnhykaZJNnHdoq4BL2gGxI5EZOU16z896EYnOQ==",
       "requires": {
         "acorn": "^6.0.1",
         "acorn-walk": "^6.0.1"
@@ -2266,65 +2286,6 @@
           "requires": {
             "remove-trailing-separator": "^1.0.1"
           }
-        }
-      }
-    },
-    "app-builder-bin": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/app-builder-bin/-/app-builder-bin-3.3.0.tgz",
-      "integrity": "sha512-FuWyffqFDfh2xFWeNae9A1RSXYo0i95EjxUA01LnhrQ2LHs71etIOiYo9wieOGRJBY5Y+evAqhaq85m7dmW+8w==",
-      "dev": true
-    },
-    "app-builder-lib": {
-      "version": "21.0.15",
-      "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-21.0.15.tgz",
-      "integrity": "sha512-WJ6xEm0G30vzEGRPmSpB4sOH5oeWDZO8GzZ6oDViiPvwTkTKbqzxkUw9NZx+9kr5JYTXcSZmB7TbIi6g1NDTEQ==",
-      "dev": true,
-      "requires": {
-        "7zip-bin": "~4.1.0",
-        "async-exit-hook": "^2.0.1",
-        "bluebird-lst": "^1.0.9",
-        "builder-util": "21.0.15",
-        "builder-util-runtime": "8.3.0",
-        "chromium-pickle-js": "^0.2.0",
-        "debug": "^4.1.1",
-        "ejs": "^2.6.2",
-        "electron-osx-sign": "0.4.11",
-        "electron-publish": "21.0.15",
-        "fs-extra": "^8.1.0",
-        "hosted-git-info": "^2.7.1",
-        "is-ci": "^2.0.0",
-        "isbinaryfile": "^4.0.1",
-        "js-yaml": "^3.13.1",
-        "lazy-val": "^1.0.4",
-        "minimatch": "^3.0.4",
-        "normalize-package-data": "^2.5.0",
-        "read-config-file": "4.0.1",
-        "sanitize-filename": "^1.6.1",
-        "semver": "^6.2.0",
-        "temp-file": "^3.3.4"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ejs": {
-          "version": "2.6.2",
-          "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.6.2.tgz",
-          "integrity": "sha512-PcW2a0tyTuPHz3tWyYqtK6r1fZ3gp+3Sop8Ph+ZYN81Ob5rwmbHEzaqs10N3BEsaGTkh/ooniXK+WwszGlc2+Q==",
-          "dev": true
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
         }
       }
     },
@@ -2650,7 +2611,6 @@
       "version": "10.0.14",
       "resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-10.0.14.tgz",
       "integrity": "sha512-T7hdxJ4xXkKW3OXcizK0pnUJlBeNj/emjQZPDIZvGOuwl2adIgicQWRNkz6BuwKdDTrqaXQn1vayaL6aL8QW5A==",
-      "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
         "@emotion/hash": "0.7.2",
@@ -2667,8 +2627,7 @@
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         }
       }
     },
@@ -3184,44 +3143,6 @@
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
       "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
       "dev": true
-    },
-    "builder-util": {
-      "version": "21.0.15",
-      "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-21.0.15.tgz",
-      "integrity": "sha512-Gto22jES/t9752CuH7O23VvRvZs2R2Gt6o74vzY5ywBb3v/+cuHk52Arf6T4xM0aprsdKe7vjgbZjCNei6HgDA==",
-      "dev": true,
-      "requires": {
-        "7zip-bin": "~4.1.0",
-        "@types/debug": "^4.1.4",
-        "app-builder-bin": "3.3.0",
-        "bluebird-lst": "^1.0.9",
-        "builder-util-runtime": "8.3.0",
-        "chalk": "^2.4.2",
-        "debug": "^4.1.1",
-        "fs-extra": "^8.1.0",
-        "is-ci": "^2.0.0",
-        "js-yaml": "^3.13.1",
-        "source-map-support": "^0.5.12",
-        "stat-mode": "^0.3.0",
-        "temp-file": "^3.3.4"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        }
-      }
     },
     "builder-util-runtime": {
       "version": "8.3.0",
@@ -3758,12 +3679,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
-      "dev": true
-    },
-    "compare-version": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/compare-version/-/compare-version-0.1.2.tgz",
-      "integrity": "sha1-AWLsLZNR9d3VmpICy6k1NmpyUIA=",
       "dev": true
     },
     "component-emitter": {
@@ -4469,14 +4384,14 @@
       }
     },
     "cssom": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.6.tgz",
-      "integrity": "sha512-DtUeseGk9/GBW0hl0vVPpU22iHL6YB5BUX7ml1hB+GMpo0NX5G4voX3kdWiMSEguFtcW3Vh3djqNF4aIe6ne0A=="
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+      "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
     },
     "cssstyle": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.2.2.tgz",
-      "integrity": "sha512-43wY3kl1CVQSvL7wUY1qXkxVGkStjpkDmVjiIKX8R97uhajy8Bybay78uOtqvh7Q5GK75dNPfW0geWjE6qQQow==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.4.0.tgz",
+      "integrity": "sha512-GBrLZYZ4X4x6/QEoBnIrqb8B/f5l4+8me2dkom/j1Gtbxy0kBv6OGzKuAsGM75bkGwGAFkt56Iwg28S3XTZgSA==",
       "requires": {
         "cssom": "0.3.x"
       }
@@ -4522,9 +4437,9 @@
       "integrity": "sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A=="
     },
     "d3-color": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.2.8.tgz",
-      "integrity": "sha512-yeANXzP37PHk0DbSTMNPhnJD+Nn4G//O5E825bR6fAfHH43hobSBpgB9G9oWVl9+XgUaQ4yCnsX1H+l8DoaL9A=="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.3.0.tgz",
+      "integrity": "sha512-NHODMBlj59xPAwl2BDiO2Mog6V+PrGRtBfWKqKRrs9MCqlSkIEb0Z/SfY7jW29ReHTDC/j+vwXhnZcXI3+3fbg=="
     },
     "d3-ease": {
       "version": "1.0.5",
@@ -4553,9 +4468,9 @@
       }
     },
     "d3-path": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.7.tgz",
-      "integrity": "sha512-q0cW1RpvA5c5ma2rch62mX8AYaiLX0+bdaSM2wxSU9tXjU4DNvkx9qiUvjkuWCj3p22UO/hlPivujqMiR9PDzA=="
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.8.tgz",
+      "integrity": "sha512-J6EfUNwcMQ+aM5YPOB8ZbgAZu6wc82f/0WFxrxwV6Ll8wBwLaHLKCqQ5Imub02JriCVVdPjgI+6P3a4EWJCxAg=="
     },
     "d3-scale": {
       "version": "1.0.7",
@@ -4887,33 +4802,6 @@
         "path-type": "^3.0.0"
       }
     },
-    "dmg-builder": {
-      "version": "21.0.15",
-      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-21.0.15.tgz",
-      "integrity": "sha512-Py8as3SXO9cskCSG4rSbFJDn7tyVNu5IficGELd/e/TVtdlbHddYPp4o29WRm1GShzgNrdJCDHeg2okfcTixew==",
-      "dev": true,
-      "requires": {
-        "app-builder-lib": "~21.0.15",
-        "bluebird-lst": "^1.0.9",
-        "builder-util": "~21.0.15",
-        "fs-extra": "^8.1.0",
-        "iconv-lite": "^0.5.0",
-        "js-yaml": "^3.13.1",
-        "parse-color": "^1.0.0",
-        "sanitize-filename": "^1.6.1"
-      },
-      "dependencies": {
-        "iconv-lite": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.5.0.tgz",
-          "integrity": "sha512-NnEhI9hIEKHOzJ4f697DMz9IQEXr/MMJ5w64vN2/4Ai+wRnvV7SBrL0KLoRlwaKVghOc7LQ5YkPLuX146b6Ydw==",
-          "dev": true,
-          "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
-          }
-        }
-      }
-    },
     "dns-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz",
@@ -5083,6 +4971,22 @@
         "safer-buffer": "^2.1.0"
       }
     },
+    "editions": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/editions/-/editions-2.1.3.tgz",
+      "integrity": "sha512-xDZyVm0A4nLgMNWVVLJvcwMjI80ShiH/27RyLiCnW1L273TcJIA25C4pwJ33AWV01OX6UriP35Xu+lH4S7HWQw==",
+      "requires": {
+        "errlop": "^1.1.1",
+        "semver": "^5.6.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+        }
+      }
+    },
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -5096,9 +5000,9 @@
       "dev": true
     },
     "electron": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-6.0.0.tgz",
-      "integrity": "sha512-JVHj0dYtvVFrzVk1TgvrdXJSyLpdvlWNLhtG8ItYZsyg9XbCOQ9OoPfgLm04FjMzKMzEl4YIN0PfGC02MTx3PQ==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-4.2.8.tgz",
+      "integrity": "sha512-/D9zfs+EWLN4yLV7tu2kWyXUnZQ3CKG1cmWbXeSFXF+0dNXQ8iFpY49dqZRoHGIBImFfp2x4N3Zc5Tu7rw3PJw==",
       "dev": true,
       "requires": {
         "@types/node": "^10.12.18",
@@ -5135,6 +5039,12 @@
         "yargs": "^13.3.0"
       },
       "dependencies": {
+        "7zip-bin": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/7zip-bin/-/7zip-bin-5.0.3.tgz",
+          "integrity": "sha512-GLyWIFBbGvpKPGo55JyRZAo4lVbnBiD52cKlw/0Vt+wnmKvWJkpZvsjVoaIolyBXDeAQKSicRtqFNPem9w0WYA==",
+          "dev": true
+        },
         "ansi-align": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.0.tgz",
@@ -5150,6 +5060,42 @@
           "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
           "dev": true
         },
+        "app-builder-bin": {
+          "version": "3.4.3",
+          "resolved": "https://registry.npmjs.org/app-builder-bin/-/app-builder-bin-3.4.3.tgz",
+          "integrity": "sha512-qMhayIwi3juerQEVJMQ76trObEbfQT0nhUdxZz9a26/3NLT3pE6awmQ8S1cEnrGugaaM5gYqR8OElcDezfmEsg==",
+          "dev": true
+        },
+        "app-builder-lib": {
+          "version": "21.2.0",
+          "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-21.2.0.tgz",
+          "integrity": "sha512-aOX/nv77/Bti6NymJDg7p9T067xD8m1ipIEJR7B4Mm1GsJWpMm9PZdXtCRiMNRjHtQS5KIljT0g17781y6qn5A==",
+          "dev": true,
+          "requires": {
+            "7zip-bin": "~5.0.3",
+            "@develar/schema-utils": "~2.1.0",
+            "async-exit-hook": "^2.0.1",
+            "bluebird-lst": "^1.0.9",
+            "builder-util": "21.2.0",
+            "builder-util-runtime": "8.3.0",
+            "chromium-pickle-js": "^0.2.0",
+            "debug": "^4.1.1",
+            "ejs": "^2.6.2",
+            "electron-publish": "21.2.0",
+            "fs-extra": "^8.1.0",
+            "hosted-git-info": "^2.7.1",
+            "is-ci": "^2.0.0",
+            "isbinaryfile": "^4.0.2",
+            "js-yaml": "^3.13.1",
+            "lazy-val": "^1.0.4",
+            "minimatch": "^3.0.4",
+            "normalize-package-data": "^2.5.0",
+            "read-config-file": "5.0.0",
+            "sanitize-filename": "^1.6.2",
+            "semver": "^6.3.0",
+            "temp-file": "^3.3.4"
+          }
+        },
         "boxen": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/boxen/-/boxen-3.2.0.tgz",
@@ -5164,6 +5110,27 @@
             "term-size": "^1.2.0",
             "type-fest": "^0.3.0",
             "widest-line": "^2.0.0"
+          }
+        },
+        "builder-util": {
+          "version": "21.2.0",
+          "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-21.2.0.tgz",
+          "integrity": "sha512-Nd6CUb6YgDY8EXAXEIegx+1kzKqyFQ5ZM5BoYkeunAlwz/zDJoH1UCyULjoS5wQe5czNClFQy07zz2bzYD0Z4A==",
+          "dev": true,
+          "requires": {
+            "7zip-bin": "~5.0.3",
+            "@types/debug": "^4.1.4",
+            "app-builder-bin": "3.4.3",
+            "bluebird-lst": "^1.0.9",
+            "builder-util-runtime": "8.3.0",
+            "chalk": "^2.4.2",
+            "debug": "^4.1.1",
+            "fs-extra": "^8.1.0",
+            "is-ci": "^2.0.0",
+            "js-yaml": "^3.13.1",
+            "source-map-support": "^0.5.13",
+            "stat-mode": "^0.3.0",
+            "temp-file": "^3.3.4"
           }
         },
         "camelcase": {
@@ -5201,6 +5168,51 @@
             "unique-string": "^1.0.0",
             "write-file-atomic": "^2.0.0",
             "xdg-basedir": "^3.0.0"
+          }
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "dmg-builder": {
+          "version": "21.2.0",
+          "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-21.2.0.tgz",
+          "integrity": "sha512-9cJEclnGy7EyKFCoHDYDf54pub/t92CQapyiUxU0w9Bj2vUvfoDagP1PMiX4XD5rPp96141h9A+QN0OB4VgvQg==",
+          "dev": true,
+          "requires": {
+            "app-builder-lib": "~21.2.0",
+            "bluebird-lst": "^1.0.9",
+            "builder-util": "~21.2.0",
+            "fs-extra": "^8.1.0",
+            "iconv-lite": "^0.5.0",
+            "js-yaml": "^3.13.1",
+            "sanitize-filename": "^1.6.2"
+          }
+        },
+        "ejs": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.6.2.tgz",
+          "integrity": "sha512-PcW2a0tyTuPHz3tWyYqtK6r1fZ3gp+3Sop8Ph+ZYN81Ob5rwmbHEzaqs10N3BEsaGTkh/ooniXK+WwszGlc2+Q==",
+          "dev": true
+        },
+        "electron-publish": {
+          "version": "21.2.0",
+          "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-21.2.0.tgz",
+          "integrity": "sha512-mWavuoWJe87iaeKd0I24dNWIaR+0yRzshjNVqGyK019H766fsPWl3caQJnVKFaEyrZRP397v4JZVG0e7s16AxA==",
+          "dev": true,
+          "requires": {
+            "bluebird-lst": "^1.0.9",
+            "builder-util": "~21.2.0",
+            "builder-util-runtime": "8.3.0",
+            "chalk": "^2.4.2",
+            "fs-extra": "^8.1.0",
+            "lazy-val": "^1.0.4",
+            "mime": "^2.4.4"
           }
         },
         "find-up": {
@@ -5246,6 +5258,15 @@
             "url-parse-lax": "^3.0.0"
           }
         },
+        "iconv-lite": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.5.0.tgz",
+          "integrity": "sha512-NnEhI9hIEKHOzJ4f697DMz9IQEXr/MMJ5w64vN2/4Ai+wRnvV7SBrL0KLoRlwaKVghOc7LQ5YkPLuX146b6Ydw==",
+          "dev": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
@@ -5257,6 +5278,15 @@
           "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-3.0.0.tgz",
           "integrity": "sha512-wsigDr1Kkschp2opC4G3yA6r9EgVA6NjRpWzIi9axXqeIaAATPRJc4uLujXe3Nd9uO8KoDyA4MD6aZSeXTADhA==",
           "dev": true
+        },
+        "json5": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
+          "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.0"
+          }
         },
         "latest-version": {
           "version": "5.1.0",
@@ -5275,6 +5305,12 @@
           "requires": {
             "pify": "^3.0.0"
           }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
         },
         "package-json": {
           "version": "6.4.0",
@@ -5300,6 +5336,20 @@
           "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
           "dev": true
         },
+        "read-config-file": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/read-config-file/-/read-config-file-5.0.0.tgz",
+          "integrity": "sha512-jIKUu+C84bfnKxyJ5j30CxCqgXWYjZLXuVE/NYlMEpeni+dhESgAeZOZd0JZbg1xTkMmnCdxksDoarkOyfEsOg==",
+          "dev": true,
+          "requires": {
+            "dotenv": "^8.0.0",
+            "dotenv-expand": "^5.1.0",
+            "fs-extra": "^8.1.0",
+            "js-yaml": "^3.13.1",
+            "json5": "^2.1.0",
+            "lazy-val": "^1.0.4"
+          }
+        },
         "registry-url": {
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-5.1.0.tgz",
@@ -5314,6 +5364,15 @@
           "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
           "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
           "dev": true
+        },
+        "sanitize-filename": {
+          "version": "1.6.2",
+          "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.2.tgz",
+          "integrity": "sha512-cmTzND7RMxUB+f7gI+4+KAVHWEg0lfXvQJdko+FXDP5bNbGIdx4KMP5pX6lv5jfT9jSf6OBbjyxjFtZQwYA/ig==",
+          "dev": true,
+          "requires": {
+            "truncate-utf8-bytes": "^1.0.0"
+          }
         },
         "string-width": {
           "version": "3.1.0",
@@ -5487,49 +5546,9 @@
       }
     },
     "electron-log": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-3.0.6.tgz",
-      "integrity": "sha512-osPLk8m9+Ylo0k/okevdHUGsKpCNGxg206TxG2Ch8slGvlTZLI0955Ig4e+nJ6fHVDxFMv5dWkn2y8hwi0aENg=="
-    },
-    "electron-osx-sign": {
-      "version": "0.4.11",
-      "resolved": "https://registry.npmjs.org/electron-osx-sign/-/electron-osx-sign-0.4.11.tgz",
-      "integrity": "sha512-VVd40nrnVqymvFrY9ZkOYgHJOvexHHYTR3di/SN+mjJ0OWhR1I8BRVj3U+Yamw6hnkZZNKZp52rqL5EFAAPFkQ==",
-      "dev": true,
-      "requires": {
-        "bluebird": "^3.5.0",
-        "compare-version": "^0.1.2",
-        "debug": "^2.6.8",
-        "isbinaryfile": "^3.0.2",
-        "minimist": "^1.2.0",
-        "plist": "^3.0.1"
-      },
-      "dependencies": {
-        "isbinaryfile": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-3.0.3.tgz",
-          "integrity": "sha512-8cJBL5tTd2OS0dM4jz07wQd5g0dCCqIhUxPIGtZfa5L6hWlvV5MHTITy/DBAsF+Oe2LS1X3krBUhNwaGUWpWxw==",
-          "dev": true,
-          "requires": {
-            "buffer-alloc": "^1.2.0"
-          }
-        }
-      }
-    },
-    "electron-publish": {
-      "version": "21.0.15",
-      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-21.0.15.tgz",
-      "integrity": "sha512-KZACt9DPEnuW6+TBCme+8HVfsD+JaQzZ4jz237jd/yQKfQD3NW8zqZw3nRveNyDAuZomEbHtIEd3+OKZKY4n3g==",
-      "dev": true,
-      "requires": {
-        "bluebird-lst": "^1.0.9",
-        "builder-util": "~21.0.15",
-        "builder-util-runtime": "8.3.0",
-        "chalk": "^2.4.2",
-        "fs-extra": "^8.1.0",
-        "lazy-val": "^1.0.4",
-        "mime": "^2.4.4"
-      }
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-3.0.7.tgz",
+      "integrity": "sha512-W5pjj9DtXjSHaJWH1VWSgBweJxeZ6OEBAIOzSbu6coKFYxXPGRyg9FAILYbnDt0iJT8r6YQqjEnYgmGJn/LoAg=="
     },
     "electron-to-chromium": {
       "version": "1.3.191",
@@ -5626,6 +5645,14 @@
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-1.0.0.tgz",
       "integrity": "sha1-QWgTO0K7BcOKNbGuQ5fIKYqzaeA=",
       "dev": true
+    },
+    "errlop": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/errlop/-/errlop-1.1.1.tgz",
+      "integrity": "sha512-WX7QjiPHhsny7/PQvrhS5VMizXXKoKCS3udaBp8gjlARdbn+XmK300eKBAAN0hGyRaTCtRpOaxK+xFVPUJ3zkw==",
+      "requires": {
+        "editions": "^2.1.2"
+      }
     },
     "errno": {
       "version": "0.1.7",
@@ -6138,24 +6165,6 @@
         "debug": "2.6.9",
         "mkdirp": "0.5.1",
         "yauzl": "2.4.1"
-      },
-      "dependencies": {
-        "fd-slicer": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
-          "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
-          "requires": {
-            "pend": "~1.2.0"
-          }
-        },
-        "yauzl": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
-          "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
-          "requires": {
-            "fd-slicer": "~1.0.1"
-          }
-        }
       }
     },
     "extsprintf": {
@@ -6198,6 +6207,14 @@
       "dev": true,
       "requires": {
         "websocket-driver": ">=0.5.1"
+      }
+    },
+    "fd-slicer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
+      "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+      "requires": {
+        "pend": "~1.2.0"
       }
     },
     "figgy-pudding": {
@@ -8347,32 +8364,6 @@
         "binaryextensions": "^2.1.2",
         "editions": "^2.1.3",
         "textextensions": "^2.4.0"
-      },
-      "dependencies": {
-        "editions": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/editions/-/editions-2.1.3.tgz",
-          "integrity": "sha512-xDZyVm0A4nLgMNWVVLJvcwMjI80ShiH/27RyLiCnW1L273TcJIA25C4pwJ33AWV01OX6UriP35Xu+lH4S7HWQw==",
-          "requires": {
-            "errlop": "^1.1.1",
-            "semver": "^5.6.0"
-          },
-          "dependencies": {
-            "semver": {
-              "version": "5.7.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-              "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
-            }
-          }
-        },
-        "errlop": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/errlop/-/errlop-1.1.1.tgz",
-          "integrity": "sha512-WX7QjiPHhsny7/PQvrhS5VMizXXKoKCS3udaBp8gjlARdbn+XmK300eKBAAN0hGyRaTCtRpOaxK+xFVPUJ3zkw==",
-          "requires": {
-            "editions": "^2.1.2"
-          }
-        }
       }
     },
     "js-base64": {
@@ -8439,11 +8430,6 @@
         "xml-name-validator": "^3.0.0"
       },
       "dependencies": {
-        "acorn": {
-          "version": "6.1.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
-          "integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA=="
-        },
         "tough-cookie": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
@@ -8666,9 +8652,9 @@
       "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw=="
     },
     "lodash-es": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.11.tgz",
-      "integrity": "sha512-DHb1ub+rMjjrxqlB3H56/6MXtm1lSksDp2rA2cNWjG8mlDUYFhUj3Di2Zn5IwSU87xLv8tNIQ7sSwE/YOX/D/Q=="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.15.tgz",
+      "integrity": "sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ=="
     },
     "lodash.isequal": {
       "version": "4.5.0",
@@ -8896,9 +8882,9 @@
       }
     },
     "merge2": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.3.tgz",
-      "integrity": "sha512-gdUU1Fwj5ep4kplwcmftruWofEFt6lfpkkr3h860CXbAB9c3hGb55EOL2ali0Td5oebvW0E1+3Sr+Ur7XfKpRA=="
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.4.tgz",
+      "integrity": "sha512-FYE8xI+6pjFOhokZu0We3S5NKCirLbCzSh2Usf3qEyr4X8U+0jNg9P8RZ4qz+V2UoECLVwSyzU3LxXBaLGtD3A=="
     },
     "methods": {
       "version": "1.1.2",
@@ -9332,9 +9318,9 @@
       "dev": true
     },
     "multistream": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/multistream/-/multistream-3.0.0.tgz",
-      "integrity": "sha512-v1Fx9uhHEpTB725/Kj8YpRCvrLhb20LeABFLw+0dkBkKUUAbDCY6CUUNzGQsJ94ji/p50wBPsRjIQXN1iOwZYA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/multistream/-/multistream-3.1.0.tgz",
+      "integrity": "sha512-zBgD3kn8izQAN/TaL1PCMv15vYpf+Vcrsfub06njuYVYlzUldzpopTlrEZ53pZVEbfn3Shtv7vRFoOv6LOV87Q==",
       "requires": {
         "inherits": "^2.0.1",
         "readable-stream": "^3.4.0"
@@ -10004,23 +9990,6 @@
         "safe-buffer": "^5.1.1"
       }
     },
-    "parse-color": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/parse-color/-/parse-color-1.0.0.tgz",
-      "integrity": "sha1-e3SLlag/A/FqlPU15S1/PZRlhhk=",
-      "dev": true,
-      "requires": {
-        "color-convert": "~0.5.0"
-      },
-      "dependencies": {
-        "color-convert": {
-          "version": "0.5.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
-          "integrity": "sha1-vbbGnOZg+t/+CwAHzER+G59ygr0=",
-          "dev": true
-        }
-      }
-    },
     "parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
@@ -10072,16 +10041,6 @@
         "update-notifier": "^2.5.0"
       },
       "dependencies": {
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
         "fs-extra": {
           "version": "7.0.1",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
@@ -10241,17 +10200,6 @@
             "locate-path": "^3.0.0"
           }
         }
-      }
-    },
-    "plist": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/plist/-/plist-3.0.1.tgz",
-      "integrity": "sha512-GpgvHHocGRyQm74b6FWEZZVRroHKE1I0/BTjAmySaohK+cUn+hZpbqXkc3KWgW3gQYkqcQej35FohcT0FRlkRQ==",
-      "dev": true,
-      "requires": {
-        "base64-js": "^1.2.3",
-        "xmlbuilder": "^9.0.7",
-        "xmldom": "0.1.x"
       }
     },
     "pn": {
@@ -10925,9 +10873,9 @@
       "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
     },
     "pretty-bytes": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.2.0.tgz",
-      "integrity": "sha512-ujANBhiUsl9AhREUDUEY1GPOharMGm8x8juS7qOHybcLi7XsKfrYQ88hSly1l2i0klXHTDYrlL8ihMCG55Dc3w=="
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.3.0.tgz",
+      "integrity": "sha512-hjGrh+P926p4R4WbaB6OckyRtO0F0/lQBiT+0gnxjV+5kjPBrfVBFCsCLbMqVQeydvIoouYTCmmEURiH3R1Bdg=="
     },
     "pretty-error": {
       "version": "2.1.1",
@@ -11189,9 +11137,9 @@
       }
     },
     "react-dropzone": {
-      "version": "10.1.5",
-      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-10.1.5.tgz",
-      "integrity": "sha512-Hbe7soBc/i1fid7K3BU8T1oUJFnYO2AicS22F2MxcueMYDfKBWqZMr5ED3CoTAMs//9t2W30eyFiXm1h4wLCqA==",
+      "version": "10.1.7",
+      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-10.1.7.tgz",
+      "integrity": "sha512-PT4DHJCQrY/2vVljupveqnlwzVRQGK7U6mhoO0ox6kSJV0EK6W1ZmZpRyHMA1S6/KUOzN+1pASUMSqV/4uAIXg==",
       "requires": {
         "attr-accept": "^1.1.3",
         "file-selector": "^0.1.11",
@@ -11309,39 +11257,6 @@
         "lodash": "^4.0.1"
       }
     },
-    "read-config-file": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/read-config-file/-/read-config-file-4.0.1.tgz",
-      "integrity": "sha512-5caED3uo2IAZMPcbh/9hx/O29s2430RLxtnFDdzxpH/epEpawOrQnGBHueotIXUrGPPIgdNQN+S/CIp2WmiSfw==",
-      "dev": true,
-      "requires": {
-        "ajv": "^6.10.1",
-        "ajv-keywords": "^3.4.1",
-        "dotenv": "^8.0.0",
-        "dotenv-expand": "^5.1.0",
-        "fs-extra": "^8.1.0",
-        "js-yaml": "^3.13.1",
-        "json5": "^2.1.0",
-        "lazy-val": "^1.0.4"
-      },
-      "dependencies": {
-        "ajv-keywords": {
-          "version": "3.4.1",
-          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.1.tgz",
-          "integrity": "sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==",
-          "dev": true
-        },
-        "json5": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
-          "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
-          "dev": true,
-          "requires": {
-            "minimist": "^1.2.0"
-          }
-        }
-      }
-    },
     "read-pkg": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
@@ -11427,9 +11342,9 @@
       }
     },
     "redux-form": {
-      "version": "8.2.4",
-      "resolved": "https://registry.npmjs.org/redux-form/-/redux-form-8.2.4.tgz",
-      "integrity": "sha512-+MMD5XWVUgrtgXBuQiIYtHstPT7Lz0Izuc6vqBr1S9+7HbGgvJg4V5qDr2nigE1V5hKgsqnoAmWOWtzXc9ErZA==",
+      "version": "8.2.5",
+      "resolved": "https://registry.npmjs.org/redux-form/-/redux-form-8.2.5.tgz",
+      "integrity": "sha512-EJ0WOMUEUo6kAQ0OFmnpg4M48LXoVyzRYpL/EzZbJAmXVnZCZ0ZAtM+ho0IIjZOW9nKYa3ilAj5J9pGueX8Gwg==",
       "requires": {
         "@babel/runtime": "^7.2.0",
         "es6-error": "^4.1.1",
@@ -11708,16 +11623,6 @@
         "request-promise-core": "1.1.2",
         "stealthy-require": "^1.1.1",
         "tough-cookie": "^2.3.3"
-      },
-      "dependencies": {
-        "request-promise-core": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.2.tgz",
-          "integrity": "sha512-UHYyq1MO8GsefGEt7EprS8UrXsm1TxEvFUX1IMTuSLU2Rh7fTIdFtl8xD7JiEYiWU2dl+NYAjCTksTehQUxPag==",
-          "requires": {
-            "lodash": "^4.17.11"
-          }
-        }
       }
     },
     "require-directory": {
@@ -11928,26 +11833,17 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
-    "sanitize-filename": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.1.tgz",
-      "integrity": "sha1-YS2hyWRz+gLczaktzVtKsWSmdyo=",
-      "dev": true,
-      "requires": {
-        "truncate-utf8-bytes": "^1.0.0"
-      }
-    },
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "saxes": {
-      "version": "3.1.10",
-      "resolved": "https://registry.npmjs.org/saxes/-/saxes-3.1.10.tgz",
-      "integrity": "sha512-G/mVZCCGhJqgS+I7wT5gBHyTNXLe2SQcu2qmhwl1OKcSHyJEXKQY2CLT+qWIxV+m6uiGMLfSOJGLQQHhklIeEQ==",
+      "version": "3.1.11",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-3.1.11.tgz",
+      "integrity": "sha512-Ydydq3zC+WYDJK1+gRxRapLIED9PWeSuuS41wqyoRmzvhhh9nc+QQrVMKJYzJFULazeGhzSV0QleN2wD3boh2g==",
       "requires": {
-        "xmlchars": "^1.3.1"
+        "xmlchars": "^2.1.1"
       }
     },
     "scheduler": {
@@ -11991,9 +11887,9 @@
       }
     },
     "semver": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.2.0.tgz",
-      "integrity": "sha512-jdFC1VdUGT/2Scgbimf7FSx9iJLXoqfglSF+gJeuNWVpiE37OIbc1jywR/GJyFdz3mnkz2/id0L0J/cr0izR5A=="
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
     },
     "semver-diff": {
       "version": "2.1.0",
@@ -12414,9 +12310,9 @@
       }
     },
     "source-map-support": {
-      "version": "0.5.12",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.12.tgz",
-      "integrity": "sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==",
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
       "requires": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -13287,9 +13183,9 @@
       "dev": true
     },
     "textextensions": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/textextensions/-/textextensions-2.4.0.tgz",
-      "integrity": "sha512-qftQXnX1DzpSV8EddtHIT0eDDEiBF8ywhFYR2lI9xrGtxqKN+CvLXhACeCIGbCpQfxxERbrkZEFb8cZcDKbVZA=="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/textextensions/-/textextensions-2.5.0.tgz",
+      "integrity": "sha512-1IkVr355eHcomgK7fgj1Xsokturx6L5S2JRT5WcRdA6v5shk9sxWuO/w/VbpQexwkXJMQIa/j1dBi3oo7+HhcA=="
     },
     "three": {
       "version": "0.106.2",
@@ -13385,9 +13281,9 @@
       "dev": true
     },
     "tiny-invariant": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.0.4.tgz",
-      "integrity": "sha512-lMhRd/djQJ3MoaHEBrw8e2/uM4rs9YMNk0iOr8rHQ0QdbM7D4l0gFl3szKdeixrlyfm9Zqi4dxHCM2qVG8ND5g=="
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.0.6.tgz",
+      "integrity": "sha512-FOyLWWVjG+aC0UqG76V53yAWdXfH8bO6FNmyZOuUrzDzK8DI3/JRY25UD7+g49JWM1LXwymsKERB+DzI0dTEQA=="
     },
     "tiny-lru": {
       "version": "6.0.1",
@@ -13395,9 +13291,9 @@
       "integrity": "sha512-k/vdHz+bFALjmik0URLWBYNuO0hCABTL5dullbZBXvFDdlL8RrKaeLR6YuHfX+6ZXOLkHw+HpNLCUA7DtLMQmg=="
     },
     "tiny-warning": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.2.tgz",
-      "integrity": "sha512-rru86D9CpQRLvsFG5XFdy0KdLAvjdQDyZCsRcuu60WtzFylDM3eAWSxEVz5kzL2Gp544XiUvPbVKtOA/txLi9Q=="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
+      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
     },
     "tinycolor2": {
       "version": "1.4.1",
@@ -13750,9 +13646,9 @@
           }
         },
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },
@@ -14028,309 +13924,484 @@
       }
     },
     "victory": {
-      "version": "32.3.3",
-      "resolved": "https://registry.npmjs.org/victory/-/victory-32.3.3.tgz",
-      "integrity": "sha512-JlHRC+EpA3Tst8LNMzGV3P1CG0TJ+/U/1ka/NPLIPpWd7ZqXxTmYlpnBTpFLm3tQmWTpiOm2tTQ867LtZ3JGQw==",
+      "version": "32.3.4",
+      "resolved": "https://registry.npmjs.org/victory/-/victory-32.3.4.tgz",
+      "integrity": "sha512-mjOtwldD35omSKUp6n43VW2PVtELShLLnaA6sxwEuSm3+6IfkmnFNxiRSDiT0WEubEtwaJ/WLPgP7MpR+Sh7qA==",
       "requires": {
-        "victory-area": "^32.3.2",
-        "victory-axis": "^32.3.2",
-        "victory-bar": "^32.3.2",
-        "victory-box-plot": "^32.3.2",
-        "victory-brush-container": "^32.3.2",
-        "victory-brush-line": "^32.3.2",
-        "victory-candlestick": "^32.3.2",
-        "victory-chart": "^32.3.2",
-        "victory-core": "^32.3.2",
-        "victory-create-container": "^32.3.3",
-        "victory-cursor-container": "^32.3.2",
-        "victory-errorbar": "^32.3.2",
-        "victory-group": "^32.3.2",
-        "victory-legend": "^32.3.2",
-        "victory-line": "^32.3.2",
-        "victory-pie": "^32.3.2",
-        "victory-polar-axis": "^32.3.2",
-        "victory-scatter": "^32.3.2",
-        "victory-selection-container": "^32.3.2",
-        "victory-shared-events": "^32.3.2",
-        "victory-stack": "^32.3.2",
-        "victory-tooltip": "^32.3.2",
-        "victory-voronoi": "^32.3.2",
-        "victory-voronoi-container": "^32.3.3",
-        "victory-zoom-container": "^32.3.2"
+        "victory-area": "^32.3.4",
+        "victory-axis": "^32.3.4",
+        "victory-bar": "^32.3.4",
+        "victory-box-plot": "^32.3.4",
+        "victory-brush-container": "^32.3.4",
+        "victory-brush-line": "^32.3.4",
+        "victory-candlestick": "^32.3.4",
+        "victory-chart": "^32.3.4",
+        "victory-core": "^32.3.4",
+        "victory-create-container": "^32.3.4",
+        "victory-cursor-container": "^32.3.4",
+        "victory-errorbar": "^32.3.4",
+        "victory-group": "^32.3.4",
+        "victory-legend": "^32.3.4",
+        "victory-line": "^32.3.4",
+        "victory-pie": "^32.3.4",
+        "victory-polar-axis": "^32.3.4",
+        "victory-scatter": "^32.3.4",
+        "victory-selection-container": "^32.3.4",
+        "victory-shared-events": "^32.3.4",
+        "victory-stack": "^32.3.4",
+        "victory-tooltip": "^32.3.4",
+        "victory-voronoi": "^32.3.4",
+        "victory-voronoi-container": "^32.3.4",
+        "victory-zoom-container": "^32.3.4"
       }
     },
     "victory-area": {
-      "version": "32.3.2",
-      "resolved": "https://registry.npmjs.org/victory-area/-/victory-area-32.3.2.tgz",
-      "integrity": "sha512-KonmBC4RdzdHU9hylIUS4Fa3m89P2K+ds27YC4s0Grb97q4FGzBivnkJqIlXJQgsYlIojK1YlUwpcBXKEUHYvQ==",
+      "version": "32.3.4",
+      "resolved": "https://registry.npmjs.org/victory-area/-/victory-area-32.3.4.tgz",
+      "integrity": "sha512-rYxmaCptT84IvhLBnIsmEFFxheKTLRVKPQvR3N8S3bUkFyVdlaEUY9CuQ5OsivqtzgTJ4Crt2GPuhdpy/6bMHw==",
       "requires": {
         "d3-shape": "^1.2.0",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.15",
         "prop-types": "^15.5.8",
-        "victory-core": "^32.3.2"
+        "victory-core": "^32.3.4"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+        }
       }
     },
     "victory-axis": {
-      "version": "32.3.2",
-      "resolved": "https://registry.npmjs.org/victory-axis/-/victory-axis-32.3.2.tgz",
-      "integrity": "sha512-rIf1h1EbiZY9GVS3IKFW5JDAlYaeDng3vVdjQq8dDo3LU4LJzWGMgD/RT4+skldbeCCTz0qYpjggwSgjRjv8Ew==",
+      "version": "32.3.4",
+      "resolved": "https://registry.npmjs.org/victory-axis/-/victory-axis-32.3.4.tgz",
+      "integrity": "sha512-Z1temhv1/eDFeJL7ajYr/HuGMMvRJKK+SlSbxejlkhfMDZP8PFJ7EKgZGB/d1/2n5sH87gWBPSWPG07tkciWxA==",
       "requires": {
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.15",
         "prop-types": "^15.5.8",
-        "victory-core": "^32.3.2"
+        "victory-core": "^32.3.4"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+        }
       }
     },
     "victory-bar": {
-      "version": "32.3.2",
-      "resolved": "https://registry.npmjs.org/victory-bar/-/victory-bar-32.3.2.tgz",
-      "integrity": "sha512-Z0rYAF3NU1FfeUqv0p8RH1HpV70F1G6H+3p0MofPnuVKQNtCc/NruJ9ZaS9IYxexdbiuYaFIx1ozd9cFpdAW8A==",
+      "version": "32.3.4",
+      "resolved": "https://registry.npmjs.org/victory-bar/-/victory-bar-32.3.4.tgz",
+      "integrity": "sha512-hE80ZDLINKIH1iPhIfw5bzYDUdB9sY02IERxwm8pTodmQJ2lJrAad0HSDiiZ6FzcAGq2nX+1//qdp3tG8Ugj+Q==",
       "requires": {
         "d3-shape": "^1.2.0",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.15",
         "prop-types": "^15.5.8",
-        "victory-core": "^32.3.2"
+        "victory-core": "^32.3.4"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+        }
       }
     },
     "victory-box-plot": {
-      "version": "32.3.2",
-      "resolved": "https://registry.npmjs.org/victory-box-plot/-/victory-box-plot-32.3.2.tgz",
-      "integrity": "sha512-ECrc2W5OxN6pBkFLlmT+qj94nfphmZm40XAp1AcdvvUYF/EKEmb0RyvhhBemK5r2syDjFBLFOgIxrdOT8n9FYA==",
+      "version": "32.3.4",
+      "resolved": "https://registry.npmjs.org/victory-box-plot/-/victory-box-plot-32.3.4.tgz",
+      "integrity": "sha512-vs6roXppyQJhMK4wn2jkwMtdU6gs5l/nEtC3gyv6DY2gBg+DhVl3wZYOQ6bJTTihajs0S+KIprnhkpSCSMHlJA==",
       "requires": {
         "d3-array": "^1.2.0",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.15",
         "prop-types": "^15.5.8",
-        "victory-core": "^32.3.2"
+        "victory-core": "^32.3.4"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+        }
       }
     },
     "victory-brush-container": {
-      "version": "32.3.2",
-      "resolved": "https://registry.npmjs.org/victory-brush-container/-/victory-brush-container-32.3.2.tgz",
-      "integrity": "sha512-ESD1DXzmt+wT6sA7JEIue+e2MxhKxG8H/i+sHAYuqxhGhXdV/zA952mjcyzx3PTZPaopHXd0s6MukM1aWbOZCA==",
+      "version": "32.3.4",
+      "resolved": "https://registry.npmjs.org/victory-brush-container/-/victory-brush-container-32.3.4.tgz",
+      "integrity": "sha512-H9Ykjn0e0aJLUXmvXaQTk232/gQaG/eY2wmNirv8fOjgosjeE3hOwXZ+O2fSYbgXPxqCplS1QsPs9GdwwzhP1Q==",
       "requires": {
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.15",
         "prop-types": "^15.5.8",
-        "victory-core": "^32.3.2"
+        "victory-core": "^32.3.4"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+        }
       }
     },
     "victory-brush-line": {
-      "version": "32.3.2",
-      "resolved": "https://registry.npmjs.org/victory-brush-line/-/victory-brush-line-32.3.2.tgz",
-      "integrity": "sha512-yj3+qoFFnQZnNtIX+J6zGjOEUkNaVKmkqQ4PDK3NHef3OUmkQsOQgladyVPjc4vtCRWb5d+9TvVjCcosUYiytw==",
+      "version": "32.3.4",
+      "resolved": "https://registry.npmjs.org/victory-brush-line/-/victory-brush-line-32.3.4.tgz",
+      "integrity": "sha512-+DNDi0b2SQL9zOooU7zCqNF3lj5yu2xwiuKtaoCnt7Ct8FCc22ErASq9fsY1GbQrUtTfp+Q4skGWwTJhoQSgLg==",
       "requires": {
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.15",
         "prop-types": "^15.5.8",
-        "victory-core": "^32.3.2"
+        "victory-core": "^32.3.4"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+        }
       }
     },
     "victory-candlestick": {
-      "version": "32.3.2",
-      "resolved": "https://registry.npmjs.org/victory-candlestick/-/victory-candlestick-32.3.2.tgz",
-      "integrity": "sha512-yplTlyDmjS5C/VOt6nFsieGzZn6lwixRI7MX5Qe5t4LLSuyY/E+b+9oya8mimo1e7s4N/hbaXo7eVEDXGExuCw==",
+      "version": "32.3.4",
+      "resolved": "https://registry.npmjs.org/victory-candlestick/-/victory-candlestick-32.3.4.tgz",
+      "integrity": "sha512-6/vhsMqFBPI9vTCPuZySdqdDIHyD/+QPuWHCivhKkLqKrscNrm6cPOkcyIz9MwS9/utxZ8bSd69O9TiALNNS2w==",
       "requires": {
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.15",
         "prop-types": "^15.5.8",
-        "victory-core": "^32.3.2"
+        "victory-core": "^32.3.4"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+        }
       }
     },
     "victory-chart": {
-      "version": "32.3.2",
-      "resolved": "https://registry.npmjs.org/victory-chart/-/victory-chart-32.3.2.tgz",
-      "integrity": "sha512-xL8FUl9EYspHWw8XIQTrFhyQAMuHidIiYsyf2920bFgZB+DPLO8zhQHMVhhjnWNVgw4gVoW3Xx7XS2YXNmmLFg==",
+      "version": "32.3.4",
+      "resolved": "https://registry.npmjs.org/victory-chart/-/victory-chart-32.3.4.tgz",
+      "integrity": "sha512-7ljfqNCUGhB9+oMjAx+KeGdZD+RO8bXQiR2KwCmPLIoyWkP/VWP7cRKQjUU2sWymOtj1DFLdSyexQJ6b949nlQ==",
       "requires": {
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.15",
         "prop-types": "^15.5.8",
         "react-fast-compare": "^2.0.0",
-        "victory-axis": "^32.3.2",
-        "victory-core": "^32.3.2",
-        "victory-polar-axis": "^32.3.2",
-        "victory-shared-events": "^32.3.2"
+        "victory-axis": "^32.3.4",
+        "victory-core": "^32.3.4",
+        "victory-polar-axis": "^32.3.4",
+        "victory-shared-events": "^32.3.4"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+        }
       }
     },
     "victory-core": {
-      "version": "32.3.2",
-      "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-32.3.2.tgz",
-      "integrity": "sha512-HXlxQOacxCuZqhXgalyz71ftLOmtOLvfaIUKTBaGqUFbaLFVhcTBwqWBM+xa7gnjOhgr/VjR5apx2X/Rr8jdgA==",
+      "version": "32.3.4",
+      "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-32.3.4.tgz",
+      "integrity": "sha512-EdBsIjZZUKti8mjyMXzhUh1Qmt5w3szHResCTDtDO1ZdazzN/wYMu3dLqVjWRoZU2MDzts2vuTHU+vIy+4Hivw==",
       "requires": {
         "d3-ease": "^1.0.0",
         "d3-interpolate": "^1.1.1",
         "d3-scale": "^1.0.0",
         "d3-shape": "^1.2.0",
         "d3-timer": "^1.0.0",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.15",
         "prop-types": "^15.5.8",
         "react-fast-compare": "^2.0.0"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+        }
       }
     },
     "victory-create-container": {
-      "version": "32.3.3",
-      "resolved": "https://registry.npmjs.org/victory-create-container/-/victory-create-container-32.3.3.tgz",
-      "integrity": "sha512-Y0NqvPAAbNgyVoU2hwz+6E4Df/qa5QV7S4OpvOyljZut/Q/R0Lx9QlGsdpz6qI1veNGvQfP0KyDiKof4kFieRg==",
+      "version": "32.3.4",
+      "resolved": "https://registry.npmjs.org/victory-create-container/-/victory-create-container-32.3.4.tgz",
+      "integrity": "sha512-jjA13GdLqZHipcxzSrXgr2mvKbkN0/Bsw4z9sKc1HQcuAjWFdrxDND2Xtwn9Yla9gJ4cOkf0fUKB/1TQD756xg==",
       "requires": {
-        "lodash": "^4.17.11",
-        "victory-brush-container": "^32.3.2",
-        "victory-core": "^32.3.2",
-        "victory-cursor-container": "^32.3.2",
-        "victory-selection-container": "^32.3.2",
-        "victory-voronoi-container": "^32.3.3",
-        "victory-zoom-container": "^32.3.2"
+        "lodash": "^4.17.15",
+        "victory-brush-container": "^32.3.4",
+        "victory-core": "^32.3.4",
+        "victory-cursor-container": "^32.3.4",
+        "victory-selection-container": "^32.3.4",
+        "victory-voronoi-container": "^32.3.4",
+        "victory-zoom-container": "^32.3.4"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+        }
       }
     },
     "victory-cursor-container": {
-      "version": "32.3.2",
-      "resolved": "https://registry.npmjs.org/victory-cursor-container/-/victory-cursor-container-32.3.2.tgz",
-      "integrity": "sha512-w5ocJVLBhPMBliJNdUBIe+BSlTJQufrtF+WiT0g9V+b32hMAiNQuG4W/bH91Mjko8mHuJnTtawBMbdgz1KGQAQ==",
+      "version": "32.3.4",
+      "resolved": "https://registry.npmjs.org/victory-cursor-container/-/victory-cursor-container-32.3.4.tgz",
+      "integrity": "sha512-pagFWRaOuEiRv2lQ/C+6cjT+aajY4TPaSp+aCjyoDtNPp2BvDJ/eydLMOaWSimfqfVMQOEv5CsgS9YOvMxcGQg==",
       "requires": {
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.15",
         "prop-types": "^15.5.8",
-        "victory-core": "^32.3.2"
+        "victory-core": "^32.3.4"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+        }
       }
     },
     "victory-errorbar": {
-      "version": "32.3.2",
-      "resolved": "https://registry.npmjs.org/victory-errorbar/-/victory-errorbar-32.3.2.tgz",
-      "integrity": "sha512-tv6euhdhFT0iL4z2BV024HqNHCcXfNso7qjJErs1AjITCMFs/6/UbZ4VWOdAq8xTmqHDCdyd8zFiGtbpuSODDQ==",
+      "version": "32.3.4",
+      "resolved": "https://registry.npmjs.org/victory-errorbar/-/victory-errorbar-32.3.4.tgz",
+      "integrity": "sha512-zFvll2PHg0bjhqZMejxubF+rxJKtEW7oY/ndOn9kAtE3JoHuFy0oc8KwMCsrnSYPXTWW3S/dG+VcHliCA/e4lg==",
       "requires": {
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.15",
         "prop-types": "^15.5.8",
-        "victory-core": "^32.3.2"
+        "victory-core": "^32.3.4"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+        }
       }
     },
     "victory-group": {
-      "version": "32.3.2",
-      "resolved": "https://registry.npmjs.org/victory-group/-/victory-group-32.3.2.tgz",
-      "integrity": "sha512-N47GVC2AW7NA9oV9UNFpRcrX2XSABUU2yoG68chnaZvNrkGxCBlkz3Y6RpxZkEkXo/VX49u/JaDLQOVhhhlM3w==",
+      "version": "32.3.4",
+      "resolved": "https://registry.npmjs.org/victory-group/-/victory-group-32.3.4.tgz",
+      "integrity": "sha512-X+uxkk21y+S0qKMv7ffx/BWrhbqLfi2bX+DFSzhOEu9H4WRmBKfhVShusf93fD0xhXbMh+LbLiEPQ1Xrl0RAfQ==",
       "requires": {
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.15",
         "prop-types": "^15.5.8",
         "react-fast-compare": "^2.0.0",
-        "victory-core": "^32.3.2"
+        "victory-core": "^32.3.4"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+        }
       }
     },
     "victory-legend": {
-      "version": "32.3.2",
-      "resolved": "https://registry.npmjs.org/victory-legend/-/victory-legend-32.3.2.tgz",
-      "integrity": "sha512-JAnlrepPUzK7FWFLQPDw/TVtC/ZweUpOYM5fL9rlOw4eX7suTHVu1pjhqOaHLK0CZXOc2uJeJe9L8TZZmRK4Gw==",
+      "version": "32.3.4",
+      "resolved": "https://registry.npmjs.org/victory-legend/-/victory-legend-32.3.4.tgz",
+      "integrity": "sha512-lLmA//b6QQF8QdiAPzfX2x4H7eoVs71iDDi2uGHnX+TVrDh8m+Idr4H5SlRGEjqXMu81/CvODXeYCcYJnWW4Qg==",
       "requires": {
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.15",
         "prop-types": "^15.5.8",
-        "victory-core": "^32.3.2"
+        "victory-core": "^32.3.4"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+        }
       }
     },
     "victory-line": {
-      "version": "32.3.2",
-      "resolved": "https://registry.npmjs.org/victory-line/-/victory-line-32.3.2.tgz",
-      "integrity": "sha512-5Mk5c+7kQw/An+TgCPOzgaYxUxtfAtt9ZGVuwJ7ru02ieL9Ev0S8Q8jJdmj9vIPE4eG60ZuumzovLz+8Mw+elQ==",
+      "version": "32.3.4",
+      "resolved": "https://registry.npmjs.org/victory-line/-/victory-line-32.3.4.tgz",
+      "integrity": "sha512-1G9KODN52gYtZeNDgolFn2T5rtpruCrTXZ2FlGFfzuSUyTwSsdvp1AGbp9sXLxHaqoAcgpIpZl78DQbhgcG3IQ==",
       "requires": {
         "d3-shape": "^1.2.0",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.15",
         "prop-types": "^15.5.8",
-        "victory-core": "^32.3.2"
+        "victory-core": "^32.3.4"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+        }
       }
     },
     "victory-pie": {
-      "version": "32.3.2",
-      "resolved": "https://registry.npmjs.org/victory-pie/-/victory-pie-32.3.2.tgz",
-      "integrity": "sha512-naNoPWWHJjt4L6rHZ5U0/L2slUKkGLqQu2OnKU8/Zfbr2pBi2JXfHLFD8RIk6v+H1zApiqpU5ID+pp05u7o7/Q==",
+      "version": "32.3.4",
+      "resolved": "https://registry.npmjs.org/victory-pie/-/victory-pie-32.3.4.tgz",
+      "integrity": "sha512-XnMj5WxfwUajVW3hmBEdqH399fDNiR5wFXqWroUFxREAVmCVRJQXERVvOEVLs8Qadaw7/hH8/iqwKfH9wMm31w==",
       "requires": {
         "d3-shape": "^1.0.0",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.15",
         "prop-types": "^15.5.8",
-        "victory-core": "^32.3.2"
+        "victory-core": "^32.3.4"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+        }
       }
     },
     "victory-polar-axis": {
-      "version": "32.3.2",
-      "resolved": "https://registry.npmjs.org/victory-polar-axis/-/victory-polar-axis-32.3.2.tgz",
-      "integrity": "sha512-2lNMEzJvDLfn720q3CyhyMGZeZRPA3C0fp3WbNyTDx9h6y1L9fDdPHtLSQRURx1UZOLDwHCHdNTD1TtNiH8txg==",
+      "version": "32.3.4",
+      "resolved": "https://registry.npmjs.org/victory-polar-axis/-/victory-polar-axis-32.3.4.tgz",
+      "integrity": "sha512-nvmN4nJDT5eCIE+8WCSgukUBa+/MoZdl8okLjMgsS/O9y2vFAWkCzl/eVta+04Dvc5Q0K74Eu1n8BLHZ4dclHQ==",
       "requires": {
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.15",
         "prop-types": "^15.5.8",
-        "victory-core": "^32.3.2"
+        "victory-core": "^32.3.4"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+        }
       }
     },
     "victory-scatter": {
-      "version": "32.3.2",
-      "resolved": "https://registry.npmjs.org/victory-scatter/-/victory-scatter-32.3.2.tgz",
-      "integrity": "sha512-5tw4CnLae0NBvQg5le7OS1KhB9O3HpXgntmK/R76+6L1DOUbuIiV+LOe6XyQYlPm1yX+dF8t1P93O3ykbqWyRg==",
+      "version": "32.3.4",
+      "resolved": "https://registry.npmjs.org/victory-scatter/-/victory-scatter-32.3.4.tgz",
+      "integrity": "sha512-5+r80dgjRkv/3SexkGVD2yXbRUnxE0cdaUov29AkEI2kmLLg00B1UbnawoNYs41yeFiCvf9fOLZ6IE86Hbe1fw==",
       "requires": {
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.15",
         "prop-types": "^15.5.8",
-        "victory-core": "^32.3.2"
+        "victory-core": "^32.3.4"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+        }
       }
     },
     "victory-selection-container": {
-      "version": "32.3.2",
-      "resolved": "https://registry.npmjs.org/victory-selection-container/-/victory-selection-container-32.3.2.tgz",
-      "integrity": "sha512-imJjWYGkRm01SGxrpbbDEW16xZpVMW0/rKFzOr0ZVZHxmP7VkEx24f7futbX+DuXEYNxDO15imLOtMYXA4yhRg==",
+      "version": "32.3.4",
+      "resolved": "https://registry.npmjs.org/victory-selection-container/-/victory-selection-container-32.3.4.tgz",
+      "integrity": "sha512-PizIfepbhPTf9O6N2colVDXZBZ1n997tJzW4XN6d3KYTQmgve89CXWTTaOfuX0MRPXTGlfv6M90P4mC8zUYcyQ==",
       "requires": {
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.15",
         "prop-types": "^15.5.8",
-        "victory-core": "^32.3.2"
+        "victory-core": "^32.3.4"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+        }
       }
     },
     "victory-shared-events": {
-      "version": "32.3.2",
-      "resolved": "https://registry.npmjs.org/victory-shared-events/-/victory-shared-events-32.3.2.tgz",
-      "integrity": "sha512-Yilbcsh5YO2QHPdpxBIRIDNO9vDKb8ml5AxuUXpJcGgAH8uaASJCKj8VjQGHWH/REnJ9u0pJuC50dB6wtPuiiw==",
+      "version": "32.3.4",
+      "resolved": "https://registry.npmjs.org/victory-shared-events/-/victory-shared-events-32.3.4.tgz",
+      "integrity": "sha512-kR4AtIiyJ7iGJ4H3NmDtq9Em4sEj09KPY2ci2tZ8VNIYNd1hIw6rCarAog3HYqCm5G0S4UpDMDWHu08fwT6QeA==",
       "requires": {
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.15",
         "prop-types": "^15.5.8",
         "react-fast-compare": "^2.0.0",
-        "victory-core": "^32.3.2"
+        "victory-core": "^32.3.4"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+        }
       }
     },
     "victory-stack": {
-      "version": "32.3.2",
-      "resolved": "https://registry.npmjs.org/victory-stack/-/victory-stack-32.3.2.tgz",
-      "integrity": "sha512-6H8Lt9OV6PYYjQI1Z2Rh5ulDhuESmP5+EIli2SZxeUqMWi2z6RbGcKCM46EMv7hTLO7CPH7FyBeTblKZeghbsA==",
+      "version": "32.3.4",
+      "resolved": "https://registry.npmjs.org/victory-stack/-/victory-stack-32.3.4.tgz",
+      "integrity": "sha512-GIHZn1+JOlvH1rTuRlOYpopAPPVBzvmQNi0kgrzFq8ZaMzJU8msbltCbutGMRzIir+LIhAWdr14kJJsZIRhDnA==",
       "requires": {
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.15",
         "prop-types": "^15.5.8",
         "react-fast-compare": "^2.0.0",
-        "victory-core": "^32.3.2"
+        "victory-core": "^32.3.4"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+        }
       }
     },
     "victory-tooltip": {
-      "version": "32.3.2",
-      "resolved": "https://registry.npmjs.org/victory-tooltip/-/victory-tooltip-32.3.2.tgz",
-      "integrity": "sha512-t4HUDrC2pEVSa7wJxDtyEUK0ngvgzmT4uplytVx6AvIS476Q47SYvLU1q667FLCKWbjR1yZHCcPOhO3+79akAw==",
+      "version": "32.3.4",
+      "resolved": "https://registry.npmjs.org/victory-tooltip/-/victory-tooltip-32.3.4.tgz",
+      "integrity": "sha512-/+1cDGboOkBAwhcxA9726Ok9eNFBpLsD8W6HDnqxQfNdAEfd3XYw67PJYJMyAocS3wTQw+LXo2lgso/3mz+R+A==",
       "requires": {
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.15",
         "prop-types": "^15.5.8",
-        "victory-core": "^32.3.2"
+        "victory-core": "^32.3.4"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+        }
       }
     },
     "victory-voronoi": {
-      "version": "32.3.2",
-      "resolved": "https://registry.npmjs.org/victory-voronoi/-/victory-voronoi-32.3.2.tgz",
-      "integrity": "sha512-Q7yTF0e1srAIfOprDAv2O8oDzmv21Y+6reslZrPOZiNISl5cxqfBQWmZJISVRoVQ/MOAF8jV5UHbq37o5914PQ==",
+      "version": "32.3.4",
+      "resolved": "https://registry.npmjs.org/victory-voronoi/-/victory-voronoi-32.3.4.tgz",
+      "integrity": "sha512-+NfLd22/v5nV70G1sFesPdmMtYog0w6YdU9jI+V6SuLSLJ+OapdSUfapprYSMVNzhNySdit8k1YheOLA57WWXA==",
       "requires": {
         "d3-voronoi": "^1.1.2",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.15",
         "prop-types": "^15.5.8",
-        "victory-core": "^32.3.2"
+        "victory-core": "^32.3.4"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+        }
       }
     },
     "victory-voronoi-container": {
-      "version": "32.3.3",
-      "resolved": "https://registry.npmjs.org/victory-voronoi-container/-/victory-voronoi-container-32.3.3.tgz",
-      "integrity": "sha512-eNFOJbM3cUZb6t83xBT3O0MT5FGlX9oxO6WMUs7kZUSMGUa5by2vjV9lJ2FdL70Ix1qnMZDpyP2aYs4vMIWGZw==",
+      "version": "32.3.4",
+      "resolved": "https://registry.npmjs.org/victory-voronoi-container/-/victory-voronoi-container-32.3.4.tgz",
+      "integrity": "sha512-2STA/CvyAS7vZxtvVnoDklKpOmddWhxekqkJdmQtotCjcC01/Y/qySsBVqb35k3fQ1wWYERzV+NIKDJdHN4ZkA==",
       "requires": {
         "delaunay-find": "0.0.3",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.15",
         "prop-types": "^15.5.8",
-        "victory-core": "^32.3.2",
-        "victory-tooltip": "^32.3.2"
+        "victory-core": "^32.3.4",
+        "victory-tooltip": "^32.3.4"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+        }
       }
     },
     "victory-zoom-container": {
-      "version": "32.3.2",
-      "resolved": "https://registry.npmjs.org/victory-zoom-container/-/victory-zoom-container-32.3.2.tgz",
-      "integrity": "sha512-XWSOwjs+kscRdf1rbonXJK+AKjWANq6E9EfQgSkfvn+nCNoRd06SffczM3EaiSVoo9R8JevEsfywblh6hQ5jQA==",
+      "version": "32.3.4",
+      "resolved": "https://registry.npmjs.org/victory-zoom-container/-/victory-zoom-container-32.3.4.tgz",
+      "integrity": "sha512-KqA4S0pfl27vjKL065IdujVEGyAC7/uGgcfcKWLcjD+ps41C40hAkNr6Pj/CiQlDVOOdNCbWwMPj30Am05Mj9Q==",
       "requires": {
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.15",
         "prop-types": "^15.5.8",
-        "victory-core": "^32.3.2"
+        "victory-core": "^32.3.4"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+        }
       }
     },
     "vm-browserify": {
@@ -15031,9 +15102,9 @@
       }
     },
     "ws": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.0.1.tgz",
-      "integrity": "sha512-ILHfMbuqLJvnSgYXLgy4kMntroJpe8hT41dOVWM8bxRuw6TK4mgMp9VJUNsZTEc5Bh+Mbs0DJT4M0N+wBG9l9A==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.1.1.tgz",
+      "integrity": "sha512-o41D/WmDeca0BqYhsr3nJzQyg9NF5X8l/UdnFNux9cS3lwB+swm8qGWX5rn+aD6xfBU3rGmtHij7g7x6LxFU3A==",
       "requires": {
         "async-limiter": "^1.0.0"
       }
@@ -15048,22 +15119,10 @@
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
       "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw=="
     },
-    "xmlbuilder": {
-      "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
-      "dev": true
-    },
     "xmlchars": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-1.3.1.tgz",
-      "integrity": "sha512-tGkGJkN8XqCod7OT+EvGYK5Z4SfDQGD30zAa58OcnAa0RRWgzUEK72tkXhsX1FZd+rgnhRxFtmO+ihkp8LHSkw=="
-    },
-    "xmldom": {
-      "version": "0.1.27",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
-      "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk=",
-      "dev": true
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.1.1.tgz",
+      "integrity": "sha512-7hew1RPJ1iIuje/Y01bGD/mXokXxegAgVS+e+E0wSi2ILHQkYAH1+JXARwTjZSM4Z4Z+c73aKspEcqj+zPPL/w=="
     },
     "xmlhttprequest": {
       "version": "1.8.0",
@@ -15176,6 +15235,14 @@
         "flat": "^4.1.0",
         "lodash": "^4.17.11",
         "yargs": "^12.0.5"
+      }
+    },
+    "yauzl": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
+      "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
+      "requires": {
+        "fd-slicer": "~1.0.1"
       }
     },
     "zip-stream": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nexus_wallet",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -5096,9 +5096,9 @@
       "dev": true
     },
     "electron": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-5.0.6.tgz",
-      "integrity": "sha512-0L53lv26eDhaaNxL6DqXGQrQOEAYbrQg40stRSb2pzrY06kwPbABzXEiaCvEsBuKUQ+9OQBbVyyvXRbLJlun/A==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-6.0.0.tgz",
+      "integrity": "sha512-JVHj0dYtvVFrzVk1TgvrdXJSyLpdvlWNLhtG8ItYZsyg9XbCOQ9OoPfgLm04FjMzKMzEl4YIN0PfGC02MTx3PQ==",
       "dev": true,
       "requires": {
         "@types/node": "^10.12.18",
@@ -5115,9 +5115,9 @@
       }
     },
     "electron-builder": {
-      "version": "21.0.15",
-      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-21.0.15.tgz",
-      "integrity": "sha512-ENvaU8+UwLAd4hIgOib1KyB1Ap119VrrEj4tBgihuKDgsNUgV7qt2YUdYA6umcUKPAE+ewWBfPLzg+q0gqWTIQ==",
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-21.2.0.tgz",
+      "integrity": "sha512-x8EXrqFbAb2L3N22YlGar3dGh8vwptbB3ovo3OF6K7NTpcsmM2zEoJv7GhFyX73rNzSG2HaWpXwGAtOp2JWiEw==",
       "dev": true,
       "requires": {
         "app-builder-lib": "21.0.15",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nexus_wallet",
   "productName": "Nexus Wallet",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "moduleSpecVersion": "0.2.0",
   "supportedModuleSpecVersion": "0.1.0",
   "buildDate": "July 19th 2019",
@@ -32,8 +32,7 @@
     "update-translations": "node ./internals/scripts/updateTranslations.js",
     "update-documentation": "./UpdateDocumentation.sh"
   },
-  "browserslist": "electron 5.0.6",
-  "main": "./build/main.prod.js",
+  "browserslist": "electron "6.0.0  "main": "./build/main.prod.js",
   "build": {
     "productName": "Nexus Wallet",
     "appId": "com.nexusearth.NexusTritium",
@@ -183,8 +182,8 @@
     "cross-env": "^5.2.0",
     "cross-spawn": "^6.0.5",
     "css-loader": "^3.0.0",
-    "electron": "^5.0.6",
-    "electron-builder": "^21.0.15",
+    "electron": "^6.0.0",
+    "electron-builder": "^21.2.0",
     "electron-devtools-installer": "^2.2.4",
     "eslint": "^6.0.1",
     "express": "^4.17.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "update-translations": "node ./internals/scripts/updateTranslations.js",
     "update-documentation": "./UpdateDocumentation.sh"
   },
-  "browserslist": "electron 6.0.0",
+  "browserslist": "electron 4.2.8",
   "main": "./build/main.prod.js",
   "build": {
     "productName": "Nexus Wallet",
@@ -183,7 +183,7 @@
     "cross-env": "^5.2.0",
     "cross-spawn": "^6.0.5",
     "css-loader": "^3.0.0",
-    "electron": "^6.0.0",
+    "electron": "^4.2.8",
     "electron-builder": "^21.2.0",
     "electron-devtools-installer": "^2.2.4",
     "eslint": "^6.0.1",

--- a/package.json.save
+++ b/package.json.save
@@ -32,7 +32,7 @@
     "update-translations": "node ./internals/scripts/updateTranslations.js",
     "update-documentation": "./UpdateDocumentation.sh"
   },
-  "browserslist": "electron 6.0.0",
+  "browserslist": "electron "
   "main": "./build/main.prod.js",
   "build": {
     "productName": "Nexus Wallet",
@@ -183,8 +183,8 @@
     "cross-env": "^5.2.0",
     "cross-spawn": "^6.0.5",
     "css-loader": "^3.0.0",
-    "electron": "^6.0.0",
-    "electron-builder": "^21.2.0",
+    "electron": "^5.0.6",
+    "electron-builder": "^21.0.15",
     "electron-devtools-installer": "^2.2.4",
     "eslint": "^6.0.1",
     "express": "^4.17.1",


### PR DESCRIPTION
-update electron 4.2.8
-update electron-builder 21.2.0
-Add more in depth instructions for building windows wallet files on Linux
should fix issue #56 on ubuntu gnome based distros (16.04-19.04), however it is still unusable on Debian 9 & 10