### PR TITLE
Fix: missing parameter register

### DIFF
--- a/src/App/UserPage/Names/CreateNameModal.js
+++ b/src/App/UserPage/Names/CreateNameModal.js
@@ -126,7 +126,7 @@ export default function CreateNameModal() {
                       name,
                       global: type === 'global',
                       namespace: type === 'namespaced' ? namespace : undefined,
-                      address: registerAddress,
+                      register: registerAddress,
                     });
                   }
                 },


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/8bfe6ce8-3a3b-4d2a-8933-1479d7a74292)

In TAO/api/build.cpp there's a check for parameters when creating a name.

One of the required parameters is 'register' and this used to be 'address'.

The Wallet interface still sends 'address' to the api when creating a new name.
